### PR TITLE
Update game_sounds_props_aperture.txt to match base P2:CE.

### DIFF
--- a/scripts/game_sounds_props_aperture.txt
+++ b/scripts/game_sounds_props_aperture.txt
@@ -485,22 +485,6 @@
 				"input_map_max" "1.0" //pitch to fade in to
 				"default_to_max" "false"	
 			}
-
-			"import_stack" "p2_update_music_spatial_portals"
-			"source_info"
-			{
-				"source"   "entity"
-			}
-			"volume_apply_occlusion"
-			{
-				"input2" "1.0"
-			}
-
-
-			"speakers_spatialize"
-			{
-				"input_radius"  "200"
-			}
 		}
 	}
 }


### PR DESCRIPTION
This PR updates `game_sounds_props_aperture.txt` to match the version found within base P2:CE.

The version within base P2:CE contains a fix to prevent the console complaining about sound operators due to the spatial sound parameter being included, however the older, broken version was present in this mod template.